### PR TITLE
Add Page Templates

### DIFF
--- a/pages/restaurants/[id].tsx
+++ b/pages/restaurants/[id].tsx
@@ -61,7 +61,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     const { id } = context.params as RestaurantParams
 
     // Get restaurant data
-    const restaurant = await DataService.getRestaurant(Array.isArray(id) ? id[0] : id);
+    const restaurant = await DataService.getRestaurant(Array.isArray(id) ? id[0] : id!);
 
     return {props: {restaurant: restaurant} }
 }

--- a/pages/restaurants/[id].tsx
+++ b/pages/restaurants/[id].tsx
@@ -11,9 +11,10 @@ const auth = getAuth();
 /** Interface for the parameter of the `ProgramView` component. */
 interface RestaurantProps {
     restaurant: Restaurant;
+    reviews: Review[];
 }
 
-export default function RestaurantView({restaurant}: RestaurantProps) {
+export default function RestaurantView({restaurant, reviews}: RestaurantProps) {
 
   /* Load user authentication hook
    - user: Once authenticated user loads, user !== null.
@@ -28,6 +29,13 @@ export default function RestaurantView({restaurant}: RestaurantProps) {
      <div>
          <h1>Restaurant</h1>
          <h3>{restaurant.name}</h3>
+         <h2>Reviews</h2>
+         {reviews?.map((reviews) =>
+          <>
+            <p><strong>{reviews.score}/5</strong></p>
+            <p>{reviews.text}</p>
+          </>)
+        }
        </div>
    );
 }
@@ -50,6 +58,7 @@ import * as DataService from '@/lib/DataService'
 import { ParsedUrlQuery } from "querystring";
 import Restaurant from "@/models/Restaurant";
 import { useAuthState } from "react-firebase-hooks/auth";
+import Review from "@/models/Review";
 
 interface RestaurantParams extends ParsedUrlQuery {
     slug: string
@@ -62,6 +71,6 @@ export async function getStaticProps(context: GetStaticPropsContext) {
 
     // Get restaurant data
     const restaurant = await DataService.getRestaurant(Array.isArray(id) ? id[0] : id!);
-
-    return {props: {restaurant: restaurant} }
+    const reviews = await DataService.getReviewsForRestaurant(Array.isArray(id) ? id[0] : id!);
+    return {props: {restaurant: restaurant, reviews: reviews} }
 }

--- a/pages/restaurants/[id].tsx
+++ b/pages/restaurants/[id].tsx
@@ -13,7 +13,7 @@ interface RestaurantProps {
     restaurant: Restaurant;
 }
 
-export default function CourseView({restaurant}: RestaurantProps) {
+export default function RestaurantView({restaurant}: RestaurantProps) {
 
   /* Load user authentication hook
    - user: Once authenticated user loads, user !== null.

--- a/pages/restaurants/[id].tsx
+++ b/pages/restaurants/[id].tsx
@@ -1,0 +1,67 @@
+import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
+import Head from "next/head";
+import { initFirebase } from '@/firebase/clientApp'
+import { getAuth, signInWithPopup, GoogleAuthProvider } from "firebase/auth";
+import { getFirestore, collection } from "firebase/firestore";
+import { useCollection } from "react-firebase-hooks/firestore";
+
+const app = initFirebase();
+const auth = getAuth();
+
+/** Interface for the parameter of the `ProgramView` component. */
+interface RestaurantProps {
+    restaurant: Restaurant;
+}
+
+export default function CourseView({restaurant}: RestaurantProps) {
+
+  /* Load user authentication hook
+   - user: Once authenticated user loads, user !== null.
+   - loading: If authenticated state is loading, loading !== null.
+   - error: If there was an error loading authentication, error !== null.
+   > If all the above == null, then it means that no user is currently signed in.
+   */
+   const [user, loading, error] = useAuthState(auth);
+
+   // Render page
+   return(
+     <div>
+         <h1>Restaurant</h1>
+         <h3>{restaurant.name}</h3>
+       </div>
+   );
+}
+
+/**
+ * Returns that paths that have to be created at build time.
+ * @returns static paths.
+ */
+export const getStaticPaths: GetStaticPaths<{ id: string }> = async () => {
+
+    // Return such that no pages need to be created at build time,
+    // and a "blocking" fallback. 
+    return {
+        paths: [], fallback: "blocking"
+    };
+}
+
+
+import * as DataService from '@/lib/DataService'
+import { ParsedUrlQuery } from "querystring";
+import Restaurant from "@/models/Restaurant";
+import { useAuthState } from "react-firebase-hooks/auth";
+
+interface RestaurantParams extends ParsedUrlQuery {
+    slug: string
+}
+
+export async function getStaticProps(context: GetStaticPropsContext) {
+
+    // Get router and ID from the URL.
+    const { id } = context.params as RestaurantParams
+
+    // Get restaurant data
+    const restaurant = await DataService.getRestaurant(Array.isArray(id) ? id[0] : id);
+
+    return {props: {restaurant: restaurant} }
+}

--- a/pages/restaurants/index.tsx
+++ b/pages/restaurants/index.tsx
@@ -9,7 +9,7 @@ import Head from 'next/head'
 const app = initFirebase();
 const auth = getAuth();
 
-/** Interface for the parameter of the `Home` component. */
+/** Interface for the parameter of the `Restaurants` component. */
 interface RestaurantsProps {
   restaurants: Restaurant[];
 }

--- a/pages/restaurants/index.tsx
+++ b/pages/restaurants/index.tsx
@@ -10,10 +10,10 @@ const app = initFirebase();
 const auth = getAuth();
 
 /** Interface for the parameter of the `Home` component. */
-interface HomeProps {
+interface RestaurantsProps {
   restaurants: Restaurant[];
 }
-export default function Home({restaurants}: HomeProps) {
+export default function Restaurants({restaurants}: RestaurantsProps) {
 
   /* Load user authentication hook
    - user: Once authenticated user loads, user !== null.
@@ -23,36 +23,14 @@ export default function Home({restaurants}: HomeProps) {
    */
   const [user, loading, error] = useAuthState(auth);
 
-  // Render a page when there is an error loading the authentication state
-  if (error) {
-    return (
-      <div>
-        <p>Error: {error.message}</p>
-      </div>
-    );
-  }
-  // Render a page when the authentication state is loading
-  if (loading) {
-    return <p>Loading...</p>;
-  }
-  // Render a page when a user is signed in and stores user data in object `user`
-  if (user) {
-    return (
-      <div>
-        <p>Signed In User: {user.email}</p>
-        <button onClick={() => auth.signOut()}>Sign out</button>
+  // Render page
+  return(
+    <div>
         <h1>Restaurants</h1>
         {restaurants?.map((restaurant) =>
           <p>{restaurant.name}</p>)
         }
       </div>
-    );
-  }
-  // Render a page when a user is not signed in
-  return (
-    <div className="App">
-      <button onClick={() => authenticate()}>Sign In</button>
-    </div>
   );
 }
 

--- a/pages/users/[id].tsx
+++ b/pages/users/[id].tsx
@@ -8,13 +8,13 @@ import { useCollection } from "react-firebase-hooks/firestore";
 const app = initFirebase();
 const auth = getAuth();
 
-/** Interface for the parameter of the `RestaurantView` component. */
-interface RestaurantProps {
-    restaurant: Restaurant;
+/** Interface for the parameter of the `UserView` component. */
+interface UserProps {
+    dbUser: User;
     reviews: Review[];
 }
 
-export default function RestaurantView({restaurant, reviews}: RestaurantProps) {
+export default function UserView({dbUser, reviews}: UserProps) {
 
   /* Load user authentication hook
    - user: Once authenticated user loads, user !== null.
@@ -27,8 +27,8 @@ export default function RestaurantView({restaurant, reviews}: RestaurantProps) {
    // Render page
    return(
      <div>
-         <h1>Restaurant</h1>
-         <h3>{restaurant.name}</h3>
+         <h1>User</h1>
+         <h3>{user?.displayName}</h3>
          <h2>Reviews</h2>
          {reviews?.map((reviews) =>
           <>
@@ -59,8 +59,9 @@ import { ParsedUrlQuery } from "querystring";
 import Restaurant from "@/models/Restaurant";
 import { useAuthState } from "react-firebase-hooks/auth";
 import Review from "@/models/Review";
+import User from "@/models/User";
 
-interface RestaurantParams extends ParsedUrlQuery {
+interface UserParams extends ParsedUrlQuery {
     slug: string
 }
 
@@ -71,10 +72,10 @@ interface RestaurantParams extends ParsedUrlQuery {
 export async function getStaticProps(context: GetStaticPropsContext) {
 
     // Get router and ID from the URL.
-    const { id } = context.params as RestaurantParams
+    const { id } = context.params as UserParams
 
     // Get restaurant data
-    const restaurant = await DataService.getRestaurant(Array.isArray(id) ? id[0] : id!);
-    const reviews = await DataService.getReviewsForRestaurant(Array.isArray(id) ? id[0] : id!);
-    return {props: {restaurant: restaurant, reviews: reviews} }
+    const dbUser = await DataService.getUser(Array.isArray(id) ? id[0] : id!);
+    const reviews = await DataService.getReviewsFromUser(Array.isArray(id) ? id[0] : id!);
+    return {props: {user: dbUser, reviews: reviews} }
 }


### PR DESCRIPTION
This pull request adds the templates for website pages. All of these pages also load the necessary data from the `DataService`.

## Major Changes
- Added the following pages:
- `/` - Homepage
- `/restaurants` - Displays all restaurants
- `/restaurants/[id]` - Display details of a certain restaurant
- `/users/[id]` - Display details of a certain user

## Future Changes
- We will need to add security on the `/users/[id]`route eventually so that only authenticated users can see their own profile.