### PR TITLE
Fix npm Install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-firebase-hooks": "^5.1.1",
+        "react-geocode": "^0.2.3",
         "typescript": "5.0.2"
       },
       "devDependencies": {
@@ -1945,6 +1946,14 @@
         "react": ">= 16.8.0"
       }
     },
+    "node_modules/react-geocode": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/react-geocode/-/react-geocode-0.2.3.tgz",
+      "integrity": "sha512-sIpbgmn1IUzAxO4haOZ6jeeFnMD8ya9PC38yiNrmJ9vPWbvAO2D/2yfCBzZjGZVUm4PRzKAc0KghXfaEnug0TQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -1965,6 +1974,11 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3749,6 +3763,14 @@
       "integrity": "sha512-y2UpWs82xs+39q5Rc/wq316ca52QsC0n8m801V+yM4IC4hbfOL4yQPVSh7w+ydstdvjN9F+lvs1WrO2VYxpmdA==",
       "requires": {}
     },
+    "react-geocode": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/react-geocode/-/react-geocode-0.2.3.tgz",
+      "integrity": "sha512-sIpbgmn1IUzAxO4haOZ6jeeFnMD8ya9PC38yiNrmJ9vPWbvAO2D/2yfCBzZjGZVUm4PRzKAc0KghXfaEnug0TQ==",
+      "requires": {
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3766,6 +3788,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-firebase-hooks": "^5.1.1",
+    "react-geocode": "^0.2.3",
     "typescript": "5.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This quick PR adds the dependencies into `package.json` so that `npm install` on a fresh install of Node works as expected.